### PR TITLE
Add option -d DIRECTORY

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Or a specific branch in an explicit way
   $ gem specific_install -l http://github.com/githubsvnclone/rdoc.git -b edge
 `
 
+Or a specific subdirectory in a repo 
+
+`
+  $ gem specific_install https://github.com/orlandohill/waxeye -d src/ruby
+`
+
 The following URI types are accepted:
 
 - http(s)://github.com/rdp/specific_install.git
@@ -71,6 +77,9 @@ The following URI types are accepted:
           `git specific_install -l rdp/specific_install -b pre-release`
       Note: This feature is new and may not fail gracefully.
 
+    -d --directory DIRECTORY in source
+      This will change the directory in the downloaded source directory
+      before building the gem. 
 
     `git_install` is aliased to the behavior of `specific_install`
       This alias is shorter and is more intention revealing of the gem's behavior.


### PR DESCRIPTION
### Rationale

There are more than a few projects which include authoritative source to gems somewhere in their project's source tree, as opposed to stand-alone gems.  This will makes it easier to cope with those situations, since specific_install primary purpose seems to be about routing around these kinds of issues.

### Usage
```
    -d --directory DIRECTORY in source
      This will change the directory in the downloaded source directory
      before building the gem.
```

### Example
- `gem specific_install steakknife/waxeye -d src/ruby -b fix_rubygem`

```
/usr/local/bin/git
Installing from git@github.com:steakknife/waxeye.git
Cloning into '/var/folders/pd/hw84_23143bdr0hrfwnx2lc00000gn/T/d20150912-33637-1jbwpe1'...
remote: Counting objects: 1719, done.
remote: Total 1719 (delta 0), reused 0 (delta 0), pack-reused 1719
Receiving objects: 100% (1719/1719), 497.24 KiB | 0 bytes/s, done.
Resolving deltas: 100% (837/837), done.
Checking connectivity... done.
Branch fix_rubygem set up to track remote branch fix_rubygem from origin.
Switched to a new branch 'fix_rubygem'
* fix_rubygem
  master
WARNING:  licenses is empty, but is recommended.  Use a license abbreviation from:
http://opensource.org/licenses/alphabetical
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: waxeye
  Version: 0.8.1
  File: waxeye-0.8.1.gem
Successfully installed
```