### PR TITLE
Use which or where to verify git exists

### DIFF
--- a/lib/rubygems/commands/specific_install_command.rb
+++ b/lib/rubygems/commands/specific_install_command.rb
@@ -58,7 +58,7 @@ class Gem::Commands::SpecificInstallCommand < Gem::Command
   end
 
   def break_unless_git_present
-    unless system("which git")
+    unless system("which git") || system("where git")
       abort("Please install git before using a git based link for specific_install")
     end
   end


### PR DESCRIPTION
The check for git introduced [here](https://github.com/rdp/specific_install/commit/b1d6d9d780f4abbe0d0f9ef2e951e650039643e4) broke this gem on Windows. This changes the check for git to use `where` (works on Windows) or `which` (works everywhere else).