### PR TITLE
Don't change directory before switching branches

### DIFF
--- a/lib/rubygems/commands/specific_install_command.rb
+++ b/lib/rubygems/commands/specific_install_command.rb
@@ -133,11 +133,12 @@ class Gem::Commands::SpecificInstallCommand < Gem::Command
   end
 
   def install_from_git(dir)
+    Dir.chdir @top_dir do
+      change_to_branch(@branch) if @branch
+      system("git submodule update --init --recursive") # issue 25
+    end
+
     Dir.chdir dir do
-      Dir.chdir @top_dir do
-        change_to_branch(@branch) if @branch
-        system("git submodule update --init --recursive") # issue 25
-      end
       # reliable method
       if install_gemspec
         success_message


### PR DESCRIPTION
`specific_install` fails if the `-d` specified directory doesn't exist in the default branch.

When you think about it, it's a slightly weird case. But I just bumped into this, so I'll just assume this will happen to other people.

The fix is a simple reordering inside `install_from_git`, so why not support this?

Basically, old order was:
* clone
* chdir
* change branch

New order is:
* clone
* change branch
* chdir

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/rdp/specific_install/31)
<!-- Reviewable:end -->
