### PR TITLE
use require_relative instead of 'autoload'.

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,2 +1,1 @@
-require "specific_install/version"
-require "rubygems/commands/specific_install_command"
+require "specific_install"

--- a/lib/specific_install.rb
+++ b/lib/specific_install.rb
@@ -1,4 +1,14 @@
 module SpecificInstall
-  autoload :SpecificInstallCommand,  'specific_install/specific_install_command'
-  autoload :Version,         'specific_install/version'
+  def self.require_relative(path)
+    if Kernel.respond_to?(:require_relative)
+      Kernel.require_relative path
+    else
+      # 1.8, adapted from:
+      # https://github.com/marcandre/backports/blob/master/lib/backports/1.9.1/kernel/require_relative.rb
+      file = caller[0].split(/:\d/, 2).first
+      Kernel.require File.expand_path(path, File.dirname(file))
+    end
+  end
+  require_relative 'rubygems/commands/specific_install_command'
+  require_relative 'specific_install/version'
 end


### PR DESCRIPTION
autoload is scheduled to be deprecated:
https://bugs.ruby-lang.org/issues/5653

require_relative doesn't scan $LOAD_PATH like `Kernel#require` does,
so it should be plenty fast.