### PR TITLE
Don't acquire a filehandle until we have a response body to write.

### DIFF
--- a/lib/rubygems/commands/specific_install_command.rb
+++ b/lib/rubygems/commands/specific_install_command.rb
@@ -130,9 +130,10 @@ class Gem::Commands::SpecificInstallCommand < Gem::Command
   end
 
   def download( full_url, output_name )
-    File.open(output_name, "wb") do |output_file|
-      uri = URI.parse(full_url)
-      output_file.write(uri.read)
+    require 'open-uri'
+    body = URI.parse(full_url).read
+    File.open(output_name, "wb") do |f|
+      f.write(body)
     end
   end
 


### PR DESCRIPTION
Besides acquiring filehandle before we need to, if `#read` or URI.parse()
were to raise it's not clear that the block form of File.open() will clean
up for us.