### PR TITLE
Don't run `git branch`

### DIFF
--- a/lib/rubygems/commands/specific_install_command.rb
+++ b/lib/rubygems/commands/specific_install_command.rb
@@ -233,7 +233,6 @@ class Gem::Commands::SpecificInstallCommand < Gem::Command
 
   def change_to_branch(branch)
     git "checkout", branch
-    git "branch"
   end
 
   def reset_to_commit(ref)


### PR DESCRIPTION
Running `git branch` will open up a pager on some machines. Also, it doesn't seem to have any purpose here.

When it opens up a pager, some users might not know that they need to press `q` to continue.

<img width="904" alt="Screen Shot 2019-11-27 at 1 47 55 PM" src="https://user-images.githubusercontent.com/2731572/69751225-a8626a80-111c-11ea-9d03-bf634ffbb7d6.png">

