### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/specific_install.gemspec
+++ b/specific_install.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
   s.platform      = Gem::Platform::RUBY
-  s.rubyforge_project = '[none]'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'sane'


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436