### PR TITLE
[check git] use shell built-in "type -a" to search for "git" executable

### DIFF
--- a/lib/rubygems/commands/specific_install_command.rb
+++ b/lib/rubygems/commands/specific_install_command.rb
@@ -71,7 +71,7 @@ class Gem::Commands::SpecificInstallCommand < Gem::Command
   end
 
   def break_unless_git_present
-    unless system("which git") || system("where git")
+    unless system("type -a git")
       abort("Please install git before using a git based link for specific_install")
     end
   end


### PR DESCRIPTION
Use shell built-in `type -a`, instead of `which`, `where` or `whereis`
as well, to check if the `git` executable is in the `$PATH` and installed.

In this case, `type` is used with the `-a` option, which returns all of
the places containing the executable file. Furthermore it will also get
functions and aliases.

Otherwise the previously used condition using `which git` or `where git` will fail when docker images based on centos:8 are used. (see issue: #48)

