### PR TITLE
This successfully swallows the error:

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,2 +1,7 @@
-require "specific_install/version"
-require "rubygems/commands/specific_install_command"
+begin
+  require "specific_install/version"
+  require "rubygems/commands/specific_install_command"
+rescue LoadError
+  # This happens with `bundle exec gem build <gemspec>` commands.
+  # But in that context we don't care.
+end


### PR DESCRIPTION
Error loading RubyGems plugin "/Users/jubishop/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/plugins/specific_install_plugin.rb": cannot load such file -- specific_install/version (LoadError)

which arises when running `bundle exec gem build <gemspec>` anywhere.  But general `gem specific_install` functionality remains and works great.