### PR TITLE
Update specific_install_command.rb

### DIFF
--- a/lib/rubygems/commands/specific_install_command.rb
+++ b/lib/rubygems/commands/specific_install_command.rb
@@ -71,7 +71,7 @@ class Gem::Commands::SpecificInstallCommand < Gem::Command
   end
 
   def break_unless_git_present
-    unless system("bash -c 'type -a git'")
+    unless system("git --version") || system("sh -c 'command -V git'")
       abort("Please install git before using a git based link for specific_install")
     end
   end

--- a/lib/rubygems/commands/specific_install_command.rb
+++ b/lib/rubygems/commands/specific_install_command.rb
@@ -71,7 +71,7 @@ class Gem::Commands::SpecificInstallCommand < Gem::Command
   end
 
   def break_unless_git_present
-    unless system("type -a git")
+    unless system("bash -c 'type -a git'")
       abort("Please install git before using a git based link for specific_install")
     end
   end


### PR DESCRIPTION
fixing #54 

using ruby's `system` to delegate the usage of builtin `type` to `bash`