### PR TITLE
Make tests compatible with Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
   workflow_dispatch:
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+jobs:
+  test:
+    name: Test on Ruby ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['2.7', '3.0', '3.1', '3.2']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rspec

--- a/specific_install.gemspec
+++ b/specific_install.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'sane'
-  s.add_development_dependency "bundler", "~> 1.3"
+  s.add_development_dependency "bundler"
   s.add_development_dependency "rake"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "simplecov-vim"


### PR DESCRIPTION
Previously, tests with Ruby version 3.2 didn't pass because the Bundler version was not compatible with the latest Ruby. Therefore, I made changes to remove the version constraint for `bundler` in gemspec.

Even though I loosened the version constraint, the tests still didn't pass. Upon reviewing the test code, I found some issues:

* Test cases are accessing private methods without using `#send`.
* One test case assumes that the `*.gem` file exists.

With this patch, I aim to ensure that specific_install_spec can be tested with ease. Additionally, I want to suggest adding a GitHub workflow to ensure tests are run whenever pull requests are submitted.