### PR TITLE
Add coverage.vim to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ InstalledFiles
 pkg
 *.gem
 .bundle
-coverage
+coverage/
+coverage.vim


### PR DESCRIPTION
When I run tests on my machine, `coverage.vim` is generated because of simplecov-vim. I think the generated file should not be managed by Git.

https://github.com/zph/simplecov-vim